### PR TITLE
Remove git config -l due to git issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
       - run: npm config set '//registry.npmjs.org/:_authToken' "${{ secrets.NPM_TOKEN }}"
       - run: yarn
       - run: yarn compile
-      - run: git config --global -l
       - run: git config --global user.email opensource@mittwald.de
       - run: git config --global user.name Mittwald Release Bot
       - run: npm version from-git


### PR DESCRIPTION
Run git config --global -l
fatal: unable to read config file '/home/runner/.gitconfig': No such file or directory

Git crashes if the file does not exists (wtf?!), but will create the file on config set commands.