### PR TITLE
Add parseLabelSelector function to create a selector object from string

### DIFF
--- a/src/label.ts
+++ b/src/label.ts
@@ -38,11 +38,12 @@ export function parseLabelSelector(input: string): Selector {
         if (regexResult !== null) {
             selector[regexResult[1]] = {
                 operator: regexResult[2] as SetBasedOperator,
-                values: regexResult[3].split(","),
+                values: regexResult[3].split(",").map((v) => v.trim()),
             };
         } else {
             const [key, operator, ...values] = item.split(/(=|!=|==)/);
-            selector[key] = operator === "=" ? values.join('') : { operator: operator as EqualityBasedOperator, values };
+            const trimmedValues = values.map((v) => v.trim());
+            selector[key.trim()] = operator === "=" ? trimmedValues.join('') : { operator: operator as EqualityBasedOperator, values: trimmedValues };
         }
     }
 

--- a/src/label.ts
+++ b/src/label.ts
@@ -1,6 +1,6 @@
-import * as _ from "lodash";
-
-export type AllowedOperator = "in"| "notin";
+export type SetBasedOperator = "in" | "notin";
+export type EqualityBasedOperator = "=" | "==" | "!=";
+export type AllowedOperator = EqualityBasedOperator | SetBasedOperator
 export interface MatchExpression {
     operator: AllowedOperator,
     values: string[]
@@ -9,16 +9,41 @@ export interface MatchExpression {
 
 export interface Selector {[l: string]: string | MatchExpression; }
 
-export function selectorToQueryString(selector: Selector): string {
-    const v: string[] = [];
-
-    _.forEach(selector, (value, label) => {
+export function selectorToString(selector: Selector, separator = ";"): string {
+    const parts = Object.entries(selector).map(([label, value]) => {
         if (typeof value === "string") {
-            v.push(label + "=" + value);
-        } else {
-            v.push(label + " "+value.operator+" (" + value.values.join(",") + ")");
+            return (label + "=" + value);
         }
+        return (label + " "+value.operator+" (" + value.values.join(",") + ")");
     });
 
-    return v.join(",");
+    return parts.join(separator);
+}
+
+export const selectorToQueryString = (selector: Selector) => selectorToString(selector, ",");
+
+/**
+ * Parse a Label Selector string to a Selector Object.
+ * Label Selectors are described in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors).
+ *
+ * Uses `;` as a separator for multiple expressions in the string.
+ */
+export function parseLabelSelector(input: string): Selector {
+    const selector: Selector = {};
+
+    for (const item of input.split(";")) {
+        const regex = new RegExp("([^\(\)]*) (in|notin) \\((.*)\\)", "i");
+        const regexResult = regex.exec(item);
+        if (regexResult !== null) {
+            selector[regexResult[1]] = {
+                operator: regexResult[2] as SetBasedOperator,
+                values: regexResult[3].split(","),
+            };
+        } else {
+            const [key, operator, ...values] = item.split(/(=|!=|==)/);
+            selector[key] = operator === "=" ? values.join('') : { operator: operator as EqualityBasedOperator, values };
+        }
+    }
+
+    return selector;
 }

--- a/src/label.ts
+++ b/src/label.ts
@@ -22,7 +22,7 @@ export function selectorToString(selector: Selector, separator = ";"): string {
 
 export const selectorToQueryString = (selector: Selector) => selectorToString(selector, ",");
 
-const setBasedSelectorRegex = new RegExp("([^\(\)]*) (in|notin) \\((.*)\\)", "i");
+const setBasedSelectorRegex = new RegExp("([^\(\) ]*) +(in|notin) +\\((.*)\\)", "i");
 
 /**
  * Parse a Label Selector string to a Selector Object.

--- a/src/label.ts
+++ b/src/label.ts
@@ -22,6 +22,8 @@ export function selectorToString(selector: Selector, separator = ";"): string {
 
 export const selectorToQueryString = (selector: Selector) => selectorToString(selector, ",");
 
+const setBasedSelectorRegex = new RegExp("([^\(\)]*) (in|notin) \\((.*)\\)", "i");
+
 /**
  * Parse a Label Selector string to a Selector Object.
  * Label Selectors are described in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors).
@@ -32,8 +34,7 @@ export function parseLabelSelector(input: string): Selector {
     const selector: Selector = {};
 
     for (const item of input.split(";")) {
-        const regex = new RegExp("([^\(\)]*) (in|notin) \\((.*)\\)", "i");
-        const regexResult = regex.exec(item);
+        const regexResult = setBasedSelectorRegex.exec(item);
         if (regexResult !== null) {
             selector[regexResult[1]] = {
                 operator: regexResult[2] as SetBasedOperator,

--- a/tests/label.test.ts
+++ b/tests/label.test.ts
@@ -1,6 +1,6 @@
-import {selectorToQueryString} from "../src/label";
+import {parseLabelSelector, Selector, selectorToQueryString, selectorToString} from "../src/label";
 
-describe("Label selector", () => {
+describe("Label selector to query string", () => {
     test("should convert to correct query parameter", () => {
         const qs = selectorToQueryString({foo: "bar"});
         expect(qs).toEqual("foo=bar");
@@ -32,3 +32,60 @@ describe("Label selector", () => {
         expect(qs).toEqual("scope in (internal,external),foo notin (bar,cafe)");
     });
 });
+
+describe("String to label selector", () => {
+    test.each<[string, { input: string, expected: Selector }]>([
+        ["for =", {input: "foo=bar", expected: {foo: "bar"}}],
+        ["for !=", {input: "foo!=bar", expected: {foo: {operator: "!=", values: ["bar"]}}}],
+        ["for ==", {input: "foo!=bar", expected: {foo: {operator: "!=", values: ["bar"]}}}],
+    ])("should parse to correct selector %s", (_, {input, expected}) => {
+        const selector = parseLabelSelector(input);
+        expect(selector).toEqual(expected);
+    });
+    test("should parse to correct selector with multiple items", () => {
+        const selector = parseLabelSelector("foo=bar;bar=baz");
+        expect(selector).toEqual({foo: "bar", bar: "baz"});
+    });
+    test("should parse to correct selector with different operators in items", () => {
+        const selector = parseLabelSelector("foo=bar;bar!=baz");
+        expect(selector).toEqual({foo: "bar", bar: {operator: "!=", values: ["baz"]}});
+    });
+    test("should parse match expression to correct selector", () => {
+        const selector = parseLabelSelector("scope in (internal,external)");
+        expect(selector).toEqual({
+            scope: {
+                operator: "in",
+                values: ["internal", "external"]
+            }
+        });
+    });
+    describe("evaluates only first operator if wrong separator is used", () => {
+        test(" for match expressions", () => {
+            const selector = parseLabelSelector("scope in (internal,external),bar notin (foo,cafe)");
+            expect(selector).toEqual({
+                "scope": {
+                    "operator": "in",
+                    "values": [
+                        "internal",
+                        "external)",
+                        "bar notin (foo",
+                        "cafe"
+                    ]
+                }
+            });
+        });
+        test("evaluates first operator if wrong separator is used for equality expressions", () => {
+            const selector = parseLabelSelector("foo=bar,bar!=baz");
+            expect(selector).toEqual({
+                "foo": "bar,bar!=baz"
+            });
+        });
+    });
+});
+
+test("string to label and label to string are compatible", () => {
+    const input = "scope in (internal,external);bar notin (foo,cafe)";
+    const selector = parseLabelSelector(input);
+    const output = selectorToString(selector);
+    expect(output).toEqual(input);
+})

--- a/tests/label.test.ts
+++ b/tests/label.test.ts
@@ -59,6 +59,15 @@ describe("String to label selector", () => {
             }
         });
     });
+    test("can handle odd whitespaces around match expression operator", () => {
+        const selector = parseLabelSelector("scope  in   (internal,external)");
+        expect(selector).toEqual({
+            scope: {
+                operator: "in",
+                values: ["internal", "external"]
+            }
+        });
+    });
     describe("evaluates only first operator if wrong separator is used", () => {
         test(" for match expressions", () => {
             const selector = parseLabelSelector("scope in (internal,external),bar notin (foo,cafe)");

--- a/tests/label.test.ts
+++ b/tests/label.test.ts
@@ -46,6 +46,10 @@ describe("String to label selector", () => {
         const selector = parseLabelSelector("foo=bar;bar=baz");
         expect(selector).toEqual({foo: "bar", bar: "baz"});
     });
+    test("trims values if spaces are used", () => {
+        const selector = parseLabelSelector("foo = bar;bar = baz");
+        expect(selector).toEqual({foo: "bar", bar: "baz"});
+    });
     test("should parse to correct selector with different operators in items", () => {
         const selector = parseLabelSelector("foo=bar;bar!=baz");
         expect(selector).toEqual({foo: "bar", bar: {operator: "!=", values: ["baz"]}});
@@ -61,6 +65,15 @@ describe("String to label selector", () => {
     });
     test("can handle odd whitespaces around match expression operator", () => {
         const selector = parseLabelSelector("scope  in   (internal,external)");
+        expect(selector).toEqual({
+            scope: {
+                operator: "in",
+                values: ["internal", "external"]
+            }
+        });
+    });
+    test("trims whitespaces around values in match expression", () => {
+        const selector = parseLabelSelector("scope in ( internal , external )");
         expect(selector).toEqual({
             scope: {
                 operator: "in",


### PR DESCRIPTION
This adds a helper function to create a `Selector` object from an input string. Usage can be seen in the tests.