### PR TITLE
use ConversionResponseStatus 

### DIFF
--- a/src/types/apiextensions/v1/conversionreview.ts
+++ b/src/types/apiextensions/v1/conversionreview.ts
@@ -1,6 +1,11 @@
-import { Resource, Status } from "../../meta";
+import { Resource } from "../../meta";
 
 export declare const apiGroup = "apiextensions.k8s.io/v1";
+
+export declare type ConversionResponseStatus = {
+    status: "Success" | "Failed";
+    message?: string;
+};
 
 export declare const conversionReviewKind = "ConversionReview";
 export declare type ConversionReview<TRequest, TResponse> = Resource<typeof conversionReviewKind, typeof apiGroup> &
@@ -22,5 +27,5 @@ export interface ConversionRequest<TObject> {
 export interface ConversionResponse<TObject> {
     uid: string;
     convertedObjects?: TObject[];
-    result: Status;
+    result: ConversionResponseStatus;
 }


### PR DESCRIPTION
The ConversionReviewResponse requires `Success` or `Failed` as `Status`.
The meta status only provided `Failure`.

https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#response