### PR TITLE
Fix npm publish to use correct git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,6 @@ jobs:
       - run: yarn compile
       - run: git config --global user.email opensource@mittwald.de
       - run: git config --global --replace-all user.name "Mittwald Release Bot"
-      - run: npm version --no-git-tag-version from-git
+      - run: npm version --no-git-tag-version "$GITHUB_REF_NAME"
       - run: cp README.md package.json dist/
       - run: cd dist && npm publish


### PR DESCRIPTION
`npm version from-git` ignores the alpha/beta suffixes. This leads to the strange behavior that the git tag `v3.6.0-beta.1` results in the npm package version `v3.6.0`.

This PR fixes this by using the environment variable `GITHUB_REF_NAME` (see [Default environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)) to set the npm package tag instead of the option `from-git`.